### PR TITLE
[#110] 헤더 드롭다운 메뉴 구현, 로그인 에러 메시지 커스텀

### DIFF
--- a/src/app/(afterLogin)/_component/Header/HeaderDropdown.tsx
+++ b/src/app/(afterLogin)/_component/Header/HeaderDropdown.tsx
@@ -1,11 +1,27 @@
 'use client';
+import { accessTokenState, userInfoState } from '@/src/app/_recoil/AuthAtom';
+import { useRouter } from 'next/navigation';
+import { useResetRecoilState } from 'recoil';
 
 interface Props {
   isActive: boolean;
 }
 
 export default function HeaderDropdown({ isActive }: Props) {
+  const router = useRouter();
+  const setUserInfoState = useResetRecoilState(userInfoState);
+  const setAccessToken = useResetRecoilState(accessTokenState);
   const buttonClass = 'h-[1.875rem] w-full rounded text-[.875rem] text-black80 hover:bg-violet8 hover:text-violet';
+
+  const handleClickLogOut = () => {
+    setUserInfoState();
+    setAccessToken();
+    localStorage.removeItem('taskifyUserData');
+    router.push('/');
+  };
+  const handleClickManageAccount = () => {
+    router.push('/mypage');
+  };
 
   return (
     <div
@@ -13,8 +29,12 @@ export default function HeaderDropdown({ isActive }: Props) {
         isActive ? 'translate-y-0.5' : 'invisible translate-y-0'
       } absolute right-5 top-[3.75rem] flex h-[4.625rem] w-[5.25rem] flex-col items-center gap-1 rounded border border-solid border-gray30 bg-white p-[.375rem] shadow-lg duration-500 ease-in-out md:right-10 lg:right-20`}
     >
-      <button className={`${buttonClass}`}>계정관리</button>
-      <button className={`${buttonClass}`}>로그아웃</button>
+      <button className={`${buttonClass}`} onClick={handleClickManageAccount}>
+        계정관리
+      </button>
+      <button className={`${buttonClass}`} onClick={handleClickLogOut}>
+        로그아웃
+      </button>
     </div>
   );
 }

--- a/src/app/(afterLogin)/_component/Header/HeaderDropdown.tsx
+++ b/src/app/(afterLogin)/_component/Header/HeaderDropdown.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+interface Props {
+  isActive: boolean;
+}
+
+export default function HeaderDropdown({ isActive }: Props) {
+  const buttonClass = 'h-[1.875rem] w-full rounded text-[.875rem] text-black80 hover:bg-violet8 hover:text-violet';
+
+  return (
+    <div
+      className={`transform ${
+        isActive ? 'translate-y-0.5' : 'invisible translate-y-0'
+      } absolute right-5 top-[3.75rem] flex h-[4.625rem] w-[5.25rem] flex-col items-center gap-1 rounded border border-solid border-gray30 bg-white p-[.375rem] shadow-lg duration-500 ease-in-out md:right-10 lg:right-20`}
+    >
+      <button className={`${buttonClass}`}>계정관리</button>
+      <button className={`${buttonClass}`}>로그아웃</button>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/_component/Header/HeaderProfile.tsx
+++ b/src/app/(afterLogin)/_component/Header/HeaderProfile.tsx
@@ -21,7 +21,7 @@ export default function HeaderProfile({ nickName, index, colorCode, profileImg }
     <>
       {profileImg?.length ? (
         <div
-          className={`h-[2.375rem] w-[2.375rem] rounded-full`}
+          className={`h-[2.125rem] w-[2.125rem] rounded-full border-2 border-white md:h-[2.375rem] md:w-[2.375rem]`}
           style={{
             backgroundImage: `url(${profileImg})`,
             backgroundPosition: 'center',
@@ -31,7 +31,7 @@ export default function HeaderProfile({ nickName, index, colorCode, profileImg }
         ></div>
       ) : (
         <div
-          className={`flex h-[2.375rem] w-[2.375rem] items-center justify-center rounded-full ${background} font-mon  text-[1rem] font-semibold text-white`}
+          className={`flex h-[2.125rem] w-[2.125rem] items-center justify-center rounded-full md:h-[2.375rem] md:w-[2.375rem] ${background} border-2 border-white font-mon text-[1rem] font-semibold text-white`}
         >
           {nickName?.charAt(0)}
         </div>

--- a/src/app/(afterLogin)/_component/Header/HeaderProfile.tsx
+++ b/src/app/(afterLogin)/_component/Header/HeaderProfile.tsx
@@ -1,6 +1,6 @@
 'use client';
 interface DefaultProfileProps {
-  nickName: string | undefined;
+  nickName: string;
   index?: number;
   colorCode?: string;
   profileImg: string;

--- a/src/app/(afterLogin)/_component/Header/HeaderProfile.tsx
+++ b/src/app/(afterLogin)/_component/Header/HeaderProfile.tsx
@@ -1,0 +1,41 @@
+'use client';
+interface DefaultProfileProps {
+  nickName: string | undefined;
+  index?: number;
+  colorCode?: string;
+  profileImg: string;
+}
+
+export default function HeaderProfile({ nickName, index, colorCode, profileImg }: DefaultProfileProps) {
+  const profileColors = ['bg-[#C4B1A2]', 'bg-[#9DD7ED]', 'bg-[#FDD446]', 'bg-[#FFC85A]'];
+  let background = 'bg-[#C4B1A2]';
+
+  if (index !== undefined) {
+    background = profileColors[index % profileColors.length];
+  }
+  if (colorCode !== undefined) {
+    background = `bg-[${colorCode}]`;
+  }
+
+  return (
+    <>
+      {profileImg?.length ? (
+        <div
+          className={`h-[2.375rem] w-[2.375rem] rounded-full`}
+          style={{
+            backgroundImage: `url(${profileImg})`,
+            backgroundPosition: 'center',
+            backgroundSize: 'cover',
+            backgroundRepeat: 'no-repeat',
+          }}
+        ></div>
+      ) : (
+        <div
+          className={`flex h-[2.375rem] w-[2.375rem] items-center justify-center rounded-full ${background} font-mon  text-[1rem] font-semibold text-white`}
+        >
+          {nickName?.charAt(0)}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/(afterLogin)/_component/Header/index.tsx
+++ b/src/app/(afterLogin)/_component/Header/index.tsx
@@ -30,9 +30,6 @@ export default function Header() {
   const [createdByMe, setCreatedByMe] = useState(false);
   const [isActiveDropdown, setActiveDropdown] = useState(false);
   const userInfo = useRecoilValue(userInfoState);
-  console.log(userInfo);
-
-  const userName = typeof window !== undefined ? '' : userInfo.nickname;
 
   const dashboardId = pathname.replace(/[^0-9]/g, '');
   const titleClass = !isMyDashboard ? 'hidden lg:block' : '';
@@ -98,19 +95,8 @@ export default function Header() {
               className='relative mr-3 flex cursor-pointer items-center gap-3 md:mr-10 lg:mr-20'
               onClick={handlePopUpDropdown}
             >
-              {userInfo.profileImageUrl ? (
-                <div className='flex items-center justify-center'>
-                  <div className='h-[2.375rem] w-[2.375rem] rounded-full border-2 border-white bg-[#A3C4A2] '></div>
-                  <div className='text-1 absolute font-mon font-bold text-white'>{DUMMY.profile}</div>
-                </div>
-              ) : (
-                <HeaderProfile
-                  nickName={userName}
-                  profileImg={'https://cdn.newsfreezone.co.kr/news/photo/202311/531104_535422_5518.jpg'}
-                />
-              )}
-
-              <div className='text-1 text-black30 hidden font-medium md:block'>{userName}</div>
+              <HeaderProfile nickName={userInfo.nickname} profileImg={userInfo.profileImageUrl} />
+              <div className='text-1 text-black30 hidden font-medium md:block'>{userInfo.nickname}</div>
             </div>
           </div>
         </div>

--- a/src/app/(afterLogin)/_component/Header/index.tsx
+++ b/src/app/(afterLogin)/_component/Header/index.tsx
@@ -15,6 +15,7 @@ import { axiosInstance } from '@/src/app/_util/axiosInstance';
 import HeaderDropdown from './HeaderDropdown';
 import { userInfoState } from '@/src/app/_recoil/AuthAtom';
 import HeaderProfile from '@/src/app/(afterLogin)/_component/Header/HeaderProfile';
+import { UserDataType } from '@/src/app/_constant/type';
 
 export default function Header() {
   const pathname = usePathname();
@@ -55,7 +56,7 @@ export default function Header() {
   useEffect(() => {
     const userDataObject = localStorage.getItem('taskifyUserData');
     if (userDataObject) {
-      const userData: UserData = JSON.parse(userDataObject);
+      const userData: UserDataType = JSON.parse(userDataObject);
       const nickname = userData.userInfo.nickname;
       setUserName(nickname);
     }
@@ -110,15 +111,4 @@ export default function Header() {
       {isActiveDropdown && <HeaderDropdown isActive={isActiveDropdown} />}
     </div>
   );
-}
-interface UserData {
-  userInfo: {
-    id: number;
-    email: string;
-    nickname: string;
-    profileImageUrl: string | null;
-    createdAt: string;
-    updatedAt: string;
-  };
-  accessToken: string;
 }

--- a/src/app/(afterLogin)/_component/Header/index.tsx
+++ b/src/app/(afterLogin)/_component/Header/index.tsx
@@ -23,6 +23,7 @@ export default function Header() {
   const [folderName, setFolderName] = useState('');
   const [createdByMe, setCreatedByMe] = useState(false);
   const [isActiveDropdown, setActiveDropdown] = useState(false);
+  const [userName, setUserName] = useState('');
   const userInfo = useRecoilValue(userInfoState);
 
   const dashboardId = pathname.replace(/[^0-9]/g, '');
@@ -45,13 +46,20 @@ export default function Header() {
     setActiveDropdown((prev) => !prev);
   };
 
-  const userData = localStorage.getItem('taskifyUserData');
-  console.log(userData);
-
   useEffect(() => {
     getFolderName();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);
+
+  //하이드레이션 문제로 작성한 코드
+  useEffect(() => {
+    const userDataObject = localStorage.getItem('taskifyUserData');
+    if (userDataObject) {
+      const userData: UserData = JSON.parse(userDataObject);
+      const nickname = userData.userInfo.nickname;
+      setUserName(nickname);
+    }
+  }, []);
 
   const handleInvitation = () => {
     callModal({ name: '초대하기', onSubmit: submitInvitation(dashboardId) });
@@ -92,8 +100,8 @@ export default function Header() {
               className='relative mr-3 flex cursor-pointer items-center gap-3 md:mr-10 lg:mr-20'
               onClick={handlePopUpDropdown}
             >
-              <HeaderProfile nickName={userInfo.nickname} profileImg={userInfo.profileImageUrl} />
-              <div className='text-1 text-black30 hidden font-medium md:block'>{userInfo.nickname}</div>
+              <HeaderProfile nickName={userName} profileImg={userInfo.profileImageUrl} />
+              <div className='text-1 text-black30 hidden font-medium md:block'>{userName}</div>
             </div>
           </div>
         </div>
@@ -102,4 +110,15 @@ export default function Header() {
       {isActiveDropdown && <HeaderDropdown isActive={isActiveDropdown} />}
     </div>
   );
+}
+interface UserData {
+  userInfo: {
+    id: number;
+    email: string;
+    nickname: string;
+    profileImageUrl: string | null;
+    createdAt: string;
+    updatedAt: string;
+  };
+  accessToken: string;
 }

--- a/src/app/(afterLogin)/_component/Header/index.tsx
+++ b/src/app/(afterLogin)/_component/Header/index.tsx
@@ -45,6 +45,9 @@ export default function Header() {
     setActiveDropdown((prev) => !prev);
   };
 
+  const userData = localStorage.getItem('taskifyUserData');
+  console.log(userData);
+
   useEffect(() => {
     getFolderName();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/app/(afterLogin)/_component/Header/index.tsx
+++ b/src/app/(afterLogin)/_component/Header/index.tsx
@@ -11,6 +11,7 @@ import submitInvitation from '../../_util/submitInvitation';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { axiosInstance } from '@/src/app/_util/axiosInstance';
+import HeaderDropdown from './HeaderDropdown';
 
 const DUMMY = {
   folder: '강나현의 대시보드',
@@ -24,6 +25,7 @@ export default function Header() {
   const [ModalType, callModal] = useRenderModal();
   const [folderName, setFolderName] = useState('');
   const [createdByMe, setCreatedByMe] = useState(false);
+  const [isActiveDropdown, setActiveDropdown] = useState(false);
 
   const dashboardId = pathname.replace(/[^0-9]/g, '');
   const titleClass = !isMyDashboard ? 'hidden lg:block' : '';
@@ -39,6 +41,10 @@ export default function Header() {
       setFolderName(data?.title);
       setCreatedByMe(data?.createdByMe);
     }
+  };
+
+  const handlePopUpDropdown = () => {
+    setActiveDropdown((prev) => !prev);
   };
 
   useEffect(() => {
@@ -81,7 +87,10 @@ export default function Header() {
             {!isMyDashboard && (
               <div className=' mr-3 h-[2.375rem] w-0 rounded-md border-[.0625rem] stroke-gray30 stroke-1 md:mr-6 lg:mr-8'></div>
             )}
-            <div className='relative mr-3 flex items-center gap-3 md:mr-10 lg:mr-20'>
+            <div
+              className='relative mr-3 flex cursor-pointer items-center gap-3 md:mr-10 lg:mr-20'
+              onClick={handlePopUpDropdown}
+            >
               <div className='flex items-center justify-center'>
                 <div className='h-[2.375rem] w-[2.375rem] rounded-full border-2 border-white bg-[#A3C4A2] '></div>
                 <div className='text-1 absolute font-mon font-bold text-white'>{DUMMY.profile}</div>
@@ -92,6 +101,7 @@ export default function Header() {
         </div>
       </div>
       {ModalType}
+      {isActiveDropdown && <HeaderDropdown isActive={isActiveDropdown} />}
     </div>
   );
 }

--- a/src/app/(afterLogin)/_component/Header/index.tsx
+++ b/src/app/(afterLogin)/_component/Header/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { usePathname } from 'next/navigation';
+import { useRecoilValue } from 'recoil';
 
 import Crown from '@/src/app/_component/Icons/Crown';
 import HeaderButton from './HeaderButton';
@@ -12,6 +13,8 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { axiosInstance } from '@/src/app/_util/axiosInstance';
 import HeaderDropdown from './HeaderDropdown';
+import { userInfoState } from '@/src/app/_recoil/AuthAtom';
+import HeaderProfile from '@/src/app/(afterLogin)/_component/Header/HeaderProfile';
 
 const DUMMY = {
   folder: '강나현의 대시보드',
@@ -26,6 +29,10 @@ export default function Header() {
   const [folderName, setFolderName] = useState('');
   const [createdByMe, setCreatedByMe] = useState(false);
   const [isActiveDropdown, setActiveDropdown] = useState(false);
+  const userInfo = useRecoilValue(userInfoState);
+  console.log(userInfo);
+
+  const userName = typeof window !== undefined ? '' : userInfo.nickname;
 
   const dashboardId = pathname.replace(/[^0-9]/g, '');
   const titleClass = !isMyDashboard ? 'hidden lg:block' : '';
@@ -91,11 +98,19 @@ export default function Header() {
               className='relative mr-3 flex cursor-pointer items-center gap-3 md:mr-10 lg:mr-20'
               onClick={handlePopUpDropdown}
             >
-              <div className='flex items-center justify-center'>
-                <div className='h-[2.375rem] w-[2.375rem] rounded-full border-2 border-white bg-[#A3C4A2] '></div>
-                <div className='text-1 absolute font-mon font-bold text-white'>{DUMMY.profile}</div>
-              </div>
-              <div className='text-1 text-black30 hidden font-medium md:block'>{DUMMY.userName}</div>
+              {userInfo.profileImageUrl ? (
+                <div className='flex items-center justify-center'>
+                  <div className='h-[2.375rem] w-[2.375rem] rounded-full border-2 border-white bg-[#A3C4A2] '></div>
+                  <div className='text-1 absolute font-mon font-bold text-white'>{DUMMY.profile}</div>
+                </div>
+              ) : (
+                <HeaderProfile
+                  nickName={userName}
+                  profileImg={'https://cdn.newsfreezone.co.kr/news/photo/202311/531104_535422_5518.jpg'}
+                />
+              )}
+
+              <div className='text-1 text-black30 hidden font-medium md:block'>{userName}</div>
             </div>
           </div>
         </div>

--- a/src/app/(afterLogin)/_component/Header/index.tsx
+++ b/src/app/(afterLogin)/_component/Header/index.tsx
@@ -16,12 +16,6 @@ import HeaderDropdown from './HeaderDropdown';
 import { userInfoState } from '@/src/app/_recoil/AuthAtom';
 import HeaderProfile from '@/src/app/(afterLogin)/_component/Header/HeaderProfile';
 
-const DUMMY = {
-  folder: '강나현의 대시보드',
-  userName: '강나현',
-  profile: 'K',
-};
-
 export default function Header() {
   const pathname = usePathname();
   const isMyDashboard = pathname === '/myboard';

--- a/src/app/(beforeLogin)/_constants/type.ts
+++ b/src/app/(beforeLogin)/_constants/type.ts
@@ -1,7 +1,7 @@
 export interface userInfoType {
   email: string | null;
   id: number | null;
-  nickname: string | undefined;
+  nickname: string;
   profileImageUrl: string;
   updatedAt: string | null;
 }

--- a/src/app/(beforeLogin)/_constants/type.ts
+++ b/src/app/(beforeLogin)/_constants/type.ts
@@ -1,8 +1,8 @@
 export interface userInfoType {
   email: string | null;
   id: number | null;
-  nickname: string | null;
-  profileImageUrl: string | null;
+  nickname: string | undefined;
+  profileImageUrl: string;
   updatedAt: string | null;
 }
 

--- a/src/app/(beforeLogin)/login/page.tsx
+++ b/src/app/(beforeLogin)/login/page.tsx
@@ -20,6 +20,7 @@ export default function LogIn() {
   const [modalType, callModal] = useRenderModal();
   const router = useRouter();
   const values = methods.watch();
+  const handleSubmit = methods.handleSubmit;
 
   const handleLogin = async () => {
     try {
@@ -40,15 +41,10 @@ export default function LogIn() {
     }
   };
 
-  const handleSubmit = (e: FormEvent) => {
-    e.preventDefault();
-    handleLogin();
-  };
-
   return (
     <AuthLayout message={AUTH_MESSAGE.logIn}>
       <FormProvider {...methods}>
-        <form onSubmit={handleSubmit} className='w-full' noValidate>
+        <form onSubmit={handleSubmit(handleLogin)} className='w-full' noValidate>
           <div className='mb-[1rem]'>
             <InputForm.EmailInput label='이메일' placeholder='이메일을 입력해 주세요' id='email' />
           </div>

--- a/src/app/(beforeLogin)/login/page.tsx
+++ b/src/app/(beforeLogin)/login/page.tsx
@@ -32,9 +32,10 @@ export default function LogIn() {
     } catch (error: unknown) {
       if (axios.isAxiosError(error)) {
         const response = error.response;
+        console.log(error);
 
-        if (response && response.status === 400 && response.data.message === '비밀번호가 일치하지 않습니다.') {
-          callModal({ name: '비밀번호가 일치하지 않습 니다.', onSubmit: () => {} });
+        if (response && response.data.message) {
+          callModal({ name: response.data.message, onSubmit: () => {} });
         }
       }
     }

--- a/src/app/(beforeLogin)/login/page.tsx
+++ b/src/app/(beforeLogin)/login/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { FormEvent } from 'react';
 import { FieldValues, FormProvider, useForm } from 'react-hook-form';
 import { useSetRecoilState } from 'recoil';
 import { useRouter } from 'next/navigation';

--- a/src/app/(beforeLogin)/login/page.tsx
+++ b/src/app/(beforeLogin)/login/page.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { FormEvent } from 'react';
 import { FieldValues, FormProvider, useForm } from 'react-hook-form';
 import { useSetRecoilState } from 'recoil';
 import { useRouter } from 'next/navigation';
@@ -58,3 +57,5 @@ export default function LogIn() {
     </AuthLayout>
   );
 }
+
+//커밋용 주석

--- a/src/app/(beforeLogin)/login/page.tsx
+++ b/src/app/(beforeLogin)/login/page.tsx
@@ -32,7 +32,6 @@ export default function LogIn() {
     } catch (error: unknown) {
       if (axios.isAxiosError(error)) {
         const response = error.response;
-        console.log(error);
 
         if (response && response.data.message) {
           callModal({ name: response.data.message, onSubmit: () => {} });

--- a/src/app/(beforeLogin)/login/page.tsx
+++ b/src/app/(beforeLogin)/login/page.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { FormEvent } from 'react';
 import { FieldValues, FormProvider, useForm } from 'react-hook-form';
 import { useSetRecoilState } from 'recoil';
 import { useRouter } from 'next/navigation';

--- a/src/app/_constant/type.ts
+++ b/src/app/_constant/type.ts
@@ -1,0 +1,11 @@
+export interface UserDataType {
+  userInfo: {
+    id: number;
+    email: string;
+    nickname: string;
+    profileImageUrl: string | null;
+    createdAt: string;
+    updatedAt: string;
+  };
+  accessToken: string;
+}

--- a/src/app/_recoil/AuthAtom/index.ts
+++ b/src/app/_recoil/AuthAtom/index.ts
@@ -14,7 +14,7 @@ export const userInfoState = atom<userInfoType>({
   default: {
     email: null,
     id: null,
-    nickname: undefined,
+    nickname: '',
     profileImageUrl: '',
     updatedAt: null,
   },

--- a/src/app/_recoil/AuthAtom/index.ts
+++ b/src/app/_recoil/AuthAtom/index.ts
@@ -1,4 +1,3 @@
-'use client';
 import { atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 import { accessTokenType, userInfoType } from '../../(beforeLogin)/_constants/type';
@@ -15,8 +14,8 @@ export const userInfoState = atom<userInfoType>({
   default: {
     email: null,
     id: null,
-    nickname: null,
-    profileImageUrl: null,
+    nickname: undefined,
+    profileImageUrl: '',
     updatedAt: null,
   },
   effects_UNSTABLE: [persistAtom],

--- a/src/app/_recoil/AuthAtom/index.ts
+++ b/src/app/_recoil/AuthAtom/index.ts
@@ -6,7 +6,7 @@ import { accessTokenType, userInfoType } from '../../(beforeLogin)/_constants/ty
 const localStorage = typeof window !== 'undefined' ? window.localStorage : undefined;
 
 const { persistAtom } = recoilPersist({
-  key: 'localStorage',
+  key: 'taskifyUserData',
   storage: localStorage,
 });
 

--- a/src/app/_util/axiosInstance.tsx
+++ b/src/app/_util/axiosInstance.tsx
@@ -1,17 +1,8 @@
 import axios from 'axios';
-import { UserDataType } from '../_constant/type';
-
-const userDataString = localStorage.getItem('taskifyUserData');
-let accessToken = '';
-
-if (userDataString) {
-  const userData: UserDataType = JSON.parse(userDataString);
-  accessToken = userData.accessToken;
-}
 
 export const axiosInstance = axios.create({
   baseURL: 'https://sp-taskify-api.vercel.app/1-3/',
   headers: {
-    Authorization: `Bearer ${accessToken}`,
+    Authorization: `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzEsInRlYW1JZCI6IjEtMyIsImlhdCI6MTcwMjk4MjAyMiwiaXNzIjoic3AtdGFza2lmeSJ9.CyJw1VGMNUVnP97QL8coPmhfCeaBZkMHZDU1KjOyAyo`,
   },
 });

--- a/src/app/_util/axiosInstance.tsx
+++ b/src/app/_util/axiosInstance.tsx
@@ -2,4 +2,8 @@ import axios from 'axios';
 
 export const axiosInstance = axios.create({
   baseURL: 'https://sp-taskify-api.vercel.app/1-3/',
+  headers: {
+    Authorization:
+      'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzEsInRlYW1JZCI6IjEtMyIsImlhdCI6MTcwMjk4MjAyMiwiaXNzIjoic3AtdGFza2lmeSJ9.CyJw1VGMNUVnP97QL8coPmhfCeaBZkMHZDU1KjOyAyo',
+  },
 });

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -58,6 +58,9 @@ const config: Config = {
         md: '745px',
         lg: '1440px',
       },
+      transitionProperty: {
+        height: 'height',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 개요

[#110] : 헤더 드롭다운 메뉴 구현

## 이슈와 PR 연동 (키워드 # 이슈번호)

close #110
resolved:#110

## 스크린샷
 로그인 에러 메시지 커스텀
![ezgif com-video-to-gif-converter](https://github.com/Codeit-Part3-Team3/Taskify/assets/142777396/0578222d-37fa-497b-bf48-fcceb0b8aed2)


 헤더 드롭다운 기능 구현 (토큰  recoil persist로 로컬 스토리지에 저장 및 삭제)
![ezgif com-video-to-gif-converter (1)](https://github.com/Codeit-Part3-Team3/Taskify/assets/142777396/be0e6595-88d5-49ea-8763-b0c17e7a61ac)

헤더 프로필 데이터 바인딩 및 css
(프로필 이미지가 있을 때 - 서버 에러로 이름은 못 받아오는 중이었습니다)
![스크린샷 2023-12-30 161535](https://github.com/Codeit-Part3-Team3/Taskify/assets/142777396/b9f0518b-0d96-4f84-9367-0c2355a7723c)
![스크린샷 2023-12-30 163205](https://github.com/Codeit-Part3-Team3/Taskify/assets/142777396/3ac184a4-8658-434c-825e-2e04516736b0)

