### PR TITLE
[#160] 로그아웃 후 메인페이지 이동시 API 오류 발생

### DIFF
--- a/src/app/(afterLogin)/_component/ProfileImgCollection/index.tsx
+++ b/src/app/(afterLogin)/_component/ProfileImgCollection/index.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import Profile from './ProfileImg';
-// import useGetMembers from '@/src/app/(afterLogin)/_util/useGetMembers';
 import { memberType } from '@/src/app/(afterLogin)/_constant/type';
 import { getMembers } from '@/src/app/_api/Dashboards';
 
@@ -11,12 +10,10 @@ interface Props {
   userId: number | null;
 }
 
-// TODO: 현재 유저 아이디, 대시보드 아이디로 교체해야함
 export default function ProfileCollection({ dashboardId, userId }: Props) {
   const [count, setCount] = useState(4);
   const [members, setMembers] = useState([]);
   const [totalCount, setTotalCount] = useState(0);
-  // const { data } = useGetMembers(+dashboardId, 6);
 
   const margin = (totalCount: number) => {
     if (totalCount <= 1) {
@@ -57,7 +54,9 @@ export default function ProfileCollection({ dashboardId, userId }: Props) {
   }, []);
 
   useEffect(() => {
-    getMemeberList();
+    if (userId) {
+      getMemeberList();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dashboardId, userId]);
   return (


### PR DESCRIPTION
## 개요

[#160] 로그아웃 후 메인페이지 이동시 API 오류 발생

로그아웃시 userInfo 에 저장되어있는 id값이 바뀌는걸로 인식되어 getMembers api 호출 문제 처리하였습니다.
## 이슈와 PR 연동 (키워드 # 이슈번호)

close #160
resolved:#160

## 스크린샷
